### PR TITLE
Add a sentinel error for status code checks

### DIFF
--- a/httpclient/roundtripper.go
+++ b/httpclient/roundtripper.go
@@ -1,8 +1,15 @@
 package httpclient
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+)
+
+var (
+	// ErrStatusCode is a sentinel error for detecting if the request has
+	// been rejected because of a non-acceptable status code
+	ErrStatusCode = errors.New("the status code returned is not acceptable for the request method")
 )
 
 // AllowableStatusCodes is a map of the allowable status codes for a specific request method
@@ -54,7 +61,12 @@ func (s StatusCheckingTripper) RoundTrip(request *http.Request) (*http.Response,
 	}
 	status := StatusCode(response.StatusCode)
 	if _, ok := allowableCodes[status]; !ok {
-		return response, fmt.Errorf("(%s), is not an acceptable status for method (%s)", status, request.Method)
+		return response, fmt.Errorf(
+			"(%w) (%s), is not an acceptable status for method (%s)",
+			ErrStatusCode,
+			status,
+			request.Method,
+		)
 	}
 	return response, nil
 }

--- a/httpclient/roundtripper_test.go
+++ b/httpclient/roundtripper_test.go
@@ -41,11 +41,19 @@ func TestStatusCheckingTripper_RoundTripFails(t *testing.T) {
 			Proto:      "https",
 		}, nil
 	}))
-	req := httptest.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
-	resp, err := roundTripper.RoundTrip(req)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := http.DefaultClient
+	client.Transport = roundTripper
+	resp, err := client.Do(req)
 	if err == nil {
 		_ = resp.Body.Close()
 		t.Fatal("expected an error got none")
+	}
+	if !errors.Is(err, httpclient.ErrStatusCode) {
+		t.Fatalf("expected error to be a status code error (%s)", err)
 	}
 }
 


### PR DESCRIPTION
This adds a sentinel error for status code checks, this enables a caller
to check whether the request failed because of a non-acceptable status
code, rather than for another reason such as a time-out.