### PR TITLE
Add a different sentinel error for server errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,3 +91,4 @@ issues:
       linters:
         - gomnd
         - scopelint
+        - dupl


### PR DESCRIPTION
As it is quite often important to be able to determine between server
errors and client errors, two different sentinel errors are provided.