### PR TITLE
Change AWS config vars to match AWS CLI

### DIFF
--- a/awscfg/awscfg.go
+++ b/awscfg/awscfg.go
@@ -10,11 +10,11 @@ import (
 var Service = dependency.Service{
 	Name: "aws-cfg",
 	ConfigFunc: func(set dependency.FlagSet) {
-		set.String("aws-access-key", "", "The key to use to communicate")
+		set.String("aws-access-key-id", "", "The key to use to communicate")
 		set.String("aws-mfa-serial-number", "", "The mfa serial number to communicate to AWS with")
-		set.String("aws-region", "eu-west-1", "The AWS region that we are accessing resources in")
+		set.String("aws-default-region", "eu-west-1", "The AWS region that we are accessing resources in")
 		set.String("aws-role-arn", "", "The AWS Role ARN to use to communicate to AWS with")
-		set.String("aws-secret-key", "", "The secret key associated with the access key, to use to communicate to AWS")
+		set.String("aws-secret-access-key", "", "The secret key associated with the access key, to use to communicate to AWS")
 		set.String("aws-session-token", "", "The session token to use to communicate to AWS with")
 		set.String("aws-endpoint-url", "", "The endpoint URL that is used as AWSs API endpoint")
 	},
@@ -24,11 +24,11 @@ var Service = dependency.Service{
 // NewAWSCfg configures an aws.Config with the given dependency.ConfigGetter
 func NewAWSCfg(config dependency.ConfigGetter) aws.Config {
 	return aws.Config{
-		AccessKey:       config.GetString("aws-access-key"),
+		AccessKey:       config.GetString("aws-access-key-id"),
 		MFASerialNumber: config.GetString("aws-mfa-serial-number"),
-		Region:          config.GetString("aws-region"),
+		Region:          config.GetString("aws-default-region"),
 		RoleARN:         config.GetString("aws-role-arn"),
-		SecretKey:       config.GetString("aws-secret-key"),
+		SecretKey:       config.GetString("aws-secret-access-key"),
 		SessionToken:    config.GetString("aws-session-token"),
 		EndpointURL:     pointer.ToStringOrNil(config.GetString("aws-endpoint-url")),
 	}


### PR DESCRIPTION
This changes the configuration flag names in `service-framework` to
match those of the AWS CLI, this keeps everything nice and standard, and
removes the need for duplicated environment variables.